### PR TITLE
Update Yubo Cai profile and CSE-CEE affiliation

### DIFF
--- a/People.html
+++ b/People.html
@@ -144,7 +144,7 @@ order: 3
       <div class="container">
         {% assign loopindex = 0 %}
         {% for person in sortedPeople %}
-        {% if person.position == "postdoc" or person.position == "phdcee" or person.position == "mtsdmeecs" or person.position == "mteecs" or person.position == "mst" or person.position == "superurop" or person.position == "phdeecs" or person.position == "phdidss" or person.position == "phdtr" or person.position == "urop" or person.position == "phdme" %}
+        {% if person.position == "postdoc" or person.position == "phdcee" or person.position == "phdcsecee" or person.position == "mtsdmeecs" or person.position == "mteecs" or person.position == "mst" or person.position == "superurop" or person.position == "phdeecs" or person.position == "phdidss" or person.position == "phdtr" or person.position == "urop" or person.position == "phdme" %}
           {% assign loopindex = loopindex | plus: 1 %}
           {% assign rowfinder = loopindex | modulo: 4 %}
           {% if rowfinder == 1 %}<div class="row person-row">{% endif %}
@@ -171,6 +171,8 @@ order: 3
                 <p class="person-position">Graduate Student (ME)</p>
               {% elsif person.position == "phdcee" %}
                 <p class="person-position">Graduate Student (CEE)</p>
+              {% elsif person.position == "phdcsecee" %}
+                <p class="person-position">Graduate Student (CSE-CEE)</p>
               {% elsif person.position == "phdidss" %}
                 <p class="person-position">Graduate Student (SES)</p>
               {% elsif person.position == "phdtr" %}

--- a/_layouts/home.html
+++ b/_layouts/home.html
@@ -93,13 +93,14 @@ title: {{site.title}}
           <div class="col-md-12" style="margin-top: 30px;">
             <h2 class="black-text">About Us</h2>
             {% assign num_phdscee = site.people | where: "position","phdcee" | size %}
+            {% assign num_phdscsecee = site.people | where: "position","phdcsecee" | size %}
             {% assign num_phdsme = site.people | where: "position","phdme" | size %}
             {% assign num_phdseecs = site.people | where: "position","phdeecs" | size %}
             {% assign num_phdsidss = site.people | where: "position","phdidss" | size %}
             {% assign num_phdstr = site.people | where: "position","phdtr" | size %}
             {% assign num_postdocs = site.people | where: "position","postdoc" | size %}
             {% assign num_visiting = site.people | where: "position","visiting" | size %}
-            {% assign num_researchers = 1 | plus: num_phdscee | plus: num_phdseecs | plus: num_phdsidss | plus: num_phdstr | plus: num_postdocs | plus: num_phdme | plus: num_visiting %}
+            {% assign num_researchers = 1 | plus: num_phdscee | plus: num_phdscsecee | plus: num_phdseecs | plus: num_phdsidss | plus: num_phdstr | plus: num_postdocs | plus: num_phdme | plus: num_visiting %}
             <p>
               Driven by societal challenges, the goal of the Zardini Lab at MIT is to
               <b>develop efficient computational tools and algorithmic approaches to formulate and solve complex, interconnected system design and autonomous decision-making problems.</b>

--- a/_people/yubo-cai.markdown
+++ b/_people/yubo-cai.markdown
@@ -3,8 +3,8 @@ layout: person
 title:  "Yubo Cai"
 last:   "Cai"
 date:   2025-06-26 00:00:00 -0700
-position: phdcee
-excerpt: ""
+position: phdcsecee
+excerpt: "Compositional co-design, optimization, and multi-agent systems."
 img: YuboCai.jpeg
 email: yubocai@mit.edu
 linkedin: yubo-cai-431966189
@@ -12,12 +12,15 @@ gscholar: g2-LuZkAAAAJ
 website: https://yubocai-poly.github.io/
 ---
 
-Yubo Cai is pursuing a Ph.D. in Systems Engineering and Civil and Environmental Engineering (CEE) at MIT. Prior to joining MIT, he earned a Bachelor of Science in Mathematics and Computer Science from École Polytechnique and subsequently pursued a Master of Science in Mathematics and Statistics (OMMS/Part C) at the University of Oxford. His research interests span a diverse range of topics, including optimization, operations research, complex and interconnected system design, and control. 
-He is particularly interested in exploring how these methodologies can be applied to intelligent transportation systems, reinforcement learning, and decision science.
+Yubo Cai is a Ph.D. student in Computational Science and System Engineering (the interdisciplinary doctoral program in CEE-CSE) at MIT. He is jointly affiliated with the Center for Computational Science and Engineering (CCSE), the Department of Civil and Environmental Engineering (CEE), and the Laboratory for Information and Decision Systems (LIDS), where he is advised by Professor Gioele Zardini.
+
+Prior to joining MIT, he earned a Bachelor of Science in Applied Mathematics and Computer Science from École Polytechnique and a Master of Science in Mathematics and Statistics (OMMS/Part C) from the University of Oxford.
+
+His research lies at the intersection of Optimization, Machine Learning, and Control Theory. He develops compositional theory and scalable algorithms for the co-design of complex, interconnected engineered systems, with an emphasis on performance, robustness, coordination, and multi-objective trade-offs. He is also interested in nonconvex optimization and higher-order methods, with applications to multi-agent systems, autonomous systems, resource allocation, and game-theoretic decision-making.
 
 ### Awards:
-- MathWorks Fellowship (2026)
-- MIT CEE Departmental Fellowship (2025)
+- MathWorks Research Fellowship (2026)
+- SPEEDWELL Foundation Transportation Fund Fellowship (2025)
 - China Oxford Scholarship Fund Awards (2024)
 - ETAPS Student Scholarship (2024)
 - Mitacs Globalink Research Scholarship (2023)


### PR DESCRIPTION
## Summary

- update Yubo Cai's profile, research interests, and awards
- add a dedicated `phdcsecee` position mapped to “Graduate Student (CSE-CEE)”
- include the new position in the homepage researcher count without changing other CEE students

## Validation

- `git diff --check`
- parsed the profile YAML front matter and verified `position: phdcsecee`
- confirmed the branch was based on the latest `main`
- full Jekyll build is delegated to the repository's GitHub Actions workflow, which provides the required Ruby 3.3 runtime
